### PR TITLE
Remove console printouts

### DIFF
--- a/dygraph-line.html
+++ b/dygraph-line.html
@@ -49,10 +49,6 @@ Often, it is used to show trend data, and the comparison of two data sets.
       ],
 
       _createGraph: function(dataChange, noHeader) {
-        console.warn('DygraphLine#_createGraph');
-        console.info(dataChange);
-        console.info(noHeader);
-
         var data = dataChange.base;
 
         if (!(data && data.length)) {

--- a/dygraph-scatter.html
+++ b/dygraph-scatter.html
@@ -104,12 +104,6 @@ Often, it is used to compare two variables in different data sets.
 //      },
 
       _createGraph: function(dataChange, x, y, label) {
-        console.warn('DygraphScatter#_createGraph');
-        console.info(dataChange);
-        console.info(x);
-        console.info(y);
-        console.info(label);
-
         var data = dataChange.base;
 
         if (!(data && data.length && x && y)) {

--- a/options-behavior.html
+++ b/options-behavior.html
@@ -98,19 +98,15 @@
     },
 
     _updateColors: function(colorsChange) {
-//      console.warn('OptionsBehavior#_updateColors');
       this.options.colors = colorsChange.base;
       if (colorsChange.base && colorsChange.base.length) {
-//        console.info('updating colors...');
         this._updateOptions({colors: colorsChange.base});
       }
     },
 
     _updateVisibility: function(visibilityChange) {
-//      console.warn('OptionsBehavior#_updateVisibility');
       this.options.visibility = visibilityChange.base;
       if (visibilityChange.base && visibilityChange.base.length) {
-//        console.info('updating visibility...');
         this._updateOptions({visibility: visibilityChange.base});
       }
     },
@@ -123,10 +119,8 @@
     },
 
     _updateOptions: function(options, blockRedraw, forceUpdate) {
-//      console.warn('OptionsBehavior#_updateOptions');
       // check graph is not destroyed and options is not empty
       if ((forceUpdate || !this.noAutoUpdate) && this.graph && this.graph.attributes_) {
-//        console.info('updating...');
         this.graph.updateOptions(options, blockRedraw || false);
       }
     },


### PR DESCRIPTION
This commit removes the "useless" console printouts. By useless I mean
the printouts who do not provide any important information to the end
user.

closes #1
